### PR TITLE
docs: Add running clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,18 @@ yarn
 
 ## Running
 
+Running the front and back end use the same Yarn commands.
+
 ```bash
+# First cd into api or web
+
 # Run for developing with automatic code reloading
 yarn run dev
 
 # Run for production
 yarn start
 
-# Only build TypeScript
+# Only build TypeScript (dev and start commands also build before running)
 yarn run build
 ```
 

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\""
+    "dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
+    "start": "yarn run build && node dist/index.js"
   },
   "dependencies": {
     "googleapis": "^44.0.0",


### PR DESCRIPTION
Adds info about yarn commands for either api / web packages.

Also adds `yarn start` command for running the api in prod.